### PR TITLE
feat: add set teams command

### DIFF
--- a/src/main/java/pugbot/core/commands/CmdSetTeams.java
+++ b/src/main/java/pugbot/core/commands/CmdSetTeams.java
@@ -1,0 +1,117 @@
+package pugbot.core.commands;
+
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.Message;
+import pugbot.Utils;
+import pugbot.core.entities.Game;
+import pugbot.core.entities.PUGTeam;
+import pugbot.core.entities.QueueManager;
+import pugbot.core.exceptions.BadArgumentsException;
+import pugbot.core.exceptions.InvalidUseException;
+
+import java.util.ArrayList;
+
+public class CmdSetTeams extends Command {
+    /**
+     * Set the teams manually by hand
+     * <p>
+     * Expected command:
+     * !setteams @player1 ... @playerN vs @playerN+1 ... @playerM
+     */
+    @Override
+    public Message execCommand(Member caller, String[] args) {
+        QueueManager qm = server.getQueueManager();
+        ArrayList<Member> firstTeamMembers = new ArrayList<>();
+        ArrayList<Member> secondTeamMembers = new ArrayList<>();
+        Game game = qm.getPlayersGame(caller);
+
+        if (game == null) {
+            throw new InvalidUseException(String.format("%s is not in-game", caller.getEffectiveName()));
+        }
+        if (!(game.isCaptain(caller))) {
+            throw new InvalidUseException("You must be a captain or admin to use this command");
+        }
+        if (game.getStatus() != Game.GameStatus.PICKING) {
+            throw new InvalidUseException("Game must be currently picking");
+        }
+
+        int maxPlayers = game.getParentQueue().getMaxPlayers();
+        // Add 1 to account for the word "vs" in the middle
+        if (args.length != maxPlayers + 1) {
+            throw new BadArgumentsException();
+        }
+
+        for (int i = 0; i < maxPlayers / 2; i++) {
+            firstTeamMembers.add(server.getMember(args[i]));
+        }
+
+        // Add 1 to account for the word "vs" in the middle
+        for (int i = (maxPlayers / 2) + 1; i < maxPlayers + 1; i++) {
+            secondTeamMembers.add(server.getMember(args[i]));
+        }
+
+        PUGTeam team0 = game.getPUGTeams()[0];
+        PUGTeam team1 = game.getPUGTeams()[1];
+        int i = 0;
+        if (firstTeamMembers.contains(team0.getCaptain())) {
+            // firstTeam corresponds to team0
+            for (Member member : firstTeamMembers) {
+                if (member != team0.getCaptain()) {
+                    team0.addPlayer(member, i);
+                    i++;
+                }
+            }
+            i = 0;
+            for (Member member : secondTeamMembers) {
+                if (member != team1.getCaptain()) {
+                    team1.addPlayer(member, i);
+                    i++;
+                }
+            }
+        } else {
+            // secondTeam corresponds to team0
+            for (Member member : secondTeamMembers) {
+                if (member != team0.getCaptain()) {
+                    team0.addPlayer(member, i);
+                    i++;
+                }
+            }
+            i = 0;
+            for (Member member : firstTeamMembers) {
+                if (member != team1.getCaptain()) {
+                    team1.addPlayer(member, i);
+                    i++;
+                }
+            }
+        }
+
+        game.setTeamsComplete();
+        return Utils.createMessage("Teams have been set!");
+    }
+
+    @Override
+    public boolean isAdminRequired() {
+        return false;
+    }
+
+    @Override
+    public boolean isGlobalCommand() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "SetTeams";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Set the teams for a game";
+    }
+
+    @Override
+    public String getHelp() {
+        return getBaseCommand() + " <team1player1> <team1player2> <team1player3> <team1player4> <team1player5> vs <team2player1> <team2player2> <team2player3> <team2player4> <team2player5>";
+    }
+
+}

--- a/src/main/java/pugbot/core/commands/CmdSetTeams.java
+++ b/src/main/java/pugbot/core/commands/CmdSetTeams.java
@@ -60,6 +60,9 @@ public class CmdSetTeams extends Command {
 
         PUGTeam team0 = game.getPUGTeams()[0];
         PUGTeam team1 = game.getPUGTeams()[1];
+        team0.clearPlayers();
+        team1.clearPlayers();
+
         int i = 0;
         if (firstTeamMembers.contains(team0.getCaptain())) {
             // firstTeam corresponds to team0

--- a/src/main/java/pugbot/core/commands/CmdSetTeams.java
+++ b/src/main/java/pugbot/core/commands/CmdSetTeams.java
@@ -29,7 +29,7 @@ public class CmdSetTeams extends Command {
             throw new InvalidUseException(String.format("%s is not in-game", caller.getEffectiveName()));
         }
         if (!(game.isCaptain(caller))) {
-            throw new InvalidUseException("You must be a captain or admin to use this command");
+            throw new InvalidUseException("You must be a captain to use this command");
         }
         if (game.getStatus() != Game.GameStatus.PICKING) {
             throw new InvalidUseException("Game must be currently picking");
@@ -42,12 +42,20 @@ public class CmdSetTeams extends Command {
         }
 
         for (int i = 0; i < maxPlayers / 2; i++) {
-            firstTeamMembers.add(server.getMember(args[i]));
+            Member member = server.getMember(args[i]);
+            if (!game.containsPlayer(member)) {
+                throw new InvalidUseException(String.format("Player %s is not in game", member.getEffectiveName()));
+            }
+            firstTeamMembers.add(member);
         }
 
         // Add 1 to account for the word "vs" in the middle
         for (int i = (maxPlayers / 2) + 1; i < maxPlayers + 1; i++) {
-            secondTeamMembers.add(server.getMember(args[i]));
+            Member member = server.getMember(args[i]);
+            if (!game.containsPlayer(member)) {
+                throw new InvalidUseException(String.format("Player %s is not in game", member.getEffectiveName()));
+            }
+            secondTeamMembers.add(member);
         }
 
         PUGTeam team0 = game.getPUGTeams()[0];

--- a/src/main/java/pugbot/core/commands/CmdSetTeams.java
+++ b/src/main/java/pugbot/core/commands/CmdSetTeams.java
@@ -29,7 +29,7 @@ public class CmdSetTeams extends Command {
             throw new InvalidUseException(String.format("%s is not in-game", caller.getEffectiveName()));
         }
         if (!(game.isCaptain(caller))) {
-            throw new InvalidUseException("You must be a captain or admin to use this command");
+            throw new InvalidUseException("You must be a captain to use this command");
         }
         if (game.getStatus() != Game.GameStatus.PICKING) {
             throw new InvalidUseException("Game must be currently picking");

--- a/src/main/java/pugbot/core/entities/CommandManager.java
+++ b/src/main/java/pugbot/core/entities/CommandManager.java
@@ -55,6 +55,7 @@ public class CommandManager {
 		addCommand(new CmdDisableCommand());
 		addCommand(new CmdEnableCommand());
 		addCommand(new CmdMatchHistory());
+		addCommand(new CmdSetTeams());
 	}
 		
 	public boolean doesCommandExist(String cmdName){

--- a/src/main/java/pugbot/core/entities/Game.java
+++ b/src/main/java/pugbot/core/entities/Game.java
@@ -19,437 +19,447 @@ import pugbot.core.entities.menus.RPSMenuController;
 import pugbot.core.entities.settings.QueueSettingsManager;
 
 public class Game {
-	private Queue parentQueue;
-	
-	private long serverId;
-	private long timestamp;
-	
-	private List<Member> players;
-	private PUGTeam[] teams = new PUGTeam[2];
-	private GameStatus status = GameStatus.PICKING;
-	private PUGPickMenuController pickController;
-	private RPSMenuController rpsController;
-	private MapPickMenuController mapPickController;
-	private ConfirmationMenu startingOrderConfirmationMenu;
+    private Queue parentQueue;
 
-	public Game(Queue queue, long serverId, List<Member> players) {
-		this.parentQueue = queue;
-		this.serverId = serverId;
-		this.timestamp = System.currentTimeMillis();
-		
-		Database.insertGame(timestamp, queue.getId(), serverId);
-		
-		if(players.size() == 2) {
-			teams[0] = new PUGTeam(players.get(0));
-			teams[1] = new PUGTeam(players.get(1));
-			this.players = players;
-			
-			status = GameStatus.PLAYING;
-			insertCaptains();
-		}
-		else {
-			int minGamesSetting = parentQueue.getSettingsManager().getMinGamesPlayedToCaptain();
-			MatchMaker mm = new MatchMaker(players, serverId, parentQueue.getId(), minGamesSetting);
-			Member[] captains = mm.getRandomizedCaptains();
-			this.players = mm.getOrderedPlayerList();
-			
-			teams[0] = new PUGTeam(captains[0]);
-			teams[1] = new PUGTeam(captains[1]);
-			
-			startRPSGame();
-		}
-		
-		sendGameStartMessages();
-	}
-	
-	public enum GameStatus {
-		PICKING,
-		PLAYING,
-		FINISHED
-	}
+    private long serverId;
+    private long timestamp;
 
-	/**
-	 * @return the list of players in this game
-	 */
-	public List<Member> getPlayers() {
-		return players;
-	}
+    private List<Member> players;
+    private PUGTeam[] teams = new PUGTeam[2];
+    private GameStatus status = GameStatus.PICKING;
+    private PUGPickMenuController pickController;
+    private RPSMenuController rpsController;
+    private MapPickMenuController mapPickController;
+    private ConfirmationMenu startingOrderConfirmationMenu;
 
-	/**
-	 * @return the start time of this game in milliseconds
-	 */
-	public long getTimestamp() {
-		return timestamp;
-	}
-	
-	/**
-	 * Substitutes one player in game with one out of game
-	 * 
-	 * @param target the player to replace
-	 * @param substitute the player that will replace the target
-	 */
-	public void sub(Member target, Member substitute){
-		players.remove(target);
-		players.add(substitute);
-		
-		if(target == teams[0].getCaptain() || target == teams[1].getCaptain()){
-			subCaptain(substitute, target);
-		}
-		else{
-			if(status == GameStatus.PLAYING){
-				if(teams[0].getPlayers().contains(target)){
-					teams[0].removePlayer(target);
-					teams[0].addPlayer(substitute, null);
-				}
-				else{
-					teams[1].removePlayer(target);
-					teams[1].addPlayer(substitute, null);
-				}
-			}
-			
-			if(status == GameStatus.PICKING && pickController != null){
-				cancelMenus();
-				startPUGPicking();
-			}
-		}
-	}
-	
-	public boolean containsPlayer(Member player){
-		return players.contains(player);
-	}
-	
-	public PUGTeam[] getPUGTeams(){
-		return teams;
-	}
+    public Game(Queue queue, long serverId, List<Member> players) {
+        this.parentQueue = queue;
+        this.serverId = serverId;
+        this.timestamp = System.currentTimeMillis();
 
-	/**
-	 * @return the name of the queue that this game is from
-	 */
-	public String getQueueName() {
-		return parentQueue.getName();
-	}
-	
-	public Queue getParentQueue(){
-		return parentQueue;
-	}
-	
-	/**
-	 * @return the current status of this game
-	 */
-	public GameStatus getStatus(){
-		return status;
-	}
-	
-	private void startRPSGame(){
-		new Thread(new Runnable(){
-			public void run(){
-				rpsController = new RPSMenuController(teams[0].getCaptain(), teams[1].getCaptain());
-				
-				if(!runController(rpsController)){
-					return;
-				}
-				
-				Member winner = rpsController.getWinner();
-				
-				if(teams[1].getCaptain() == winner) {
-					teams[1].setCaptain(teams[0].getCaptain());
-					teams[0].setCaptain(winner);
-				}
-				
-				startConfirmationMenu();
-			}
-		}).start();
-	}
-	
-	private void startConfirmationMenu() {
-		new Thread(new Runnable() {
-			public void run() {
-				startingOrderConfirmationMenu = new ConfirmationMenu(teams[0].getCaptain(), "Take first pick?");
-				
-				if(!runController(startingOrderConfirmationMenu)){
-					return;
-				}
-				
-				if(!startingOrderConfirmationMenu.getResult()) {
-					Member tmp = teams[0].getCaptain();
-					
-					teams[0].setCaptain(teams[1].getCaptain());
-					teams[1].setCaptain(tmp);
-				}
-				
-				startPUGPicking();
-			}
-		}).start();
-	}
-	
-	private void startPUGPicking(){
-		new Thread(new Runnable(){
-			public void run(){
-				List<Member> playerPool = new ArrayList<Member>(players);
-				String pickingPattern = parentQueue.getSettingsManager().getPickPattern();
-				
-				playerPool.remove(teams[0].getCaptain());
-				playerPool.remove(teams[1].getCaptain());
-				
-				pickController = 
-						new PUGPickMenuController(teams[0].getCaptain(), teams[1].getCaptain(), playerPool, pickingPattern);
+        Database.insertGame(timestamp, queue.getId(), serverId);
 
-				if(!runController(pickController)) {
-					return;
-				}
-				
-				startMapPicking();
-			}
-		}).start();
-	}
-	
-	private void startMapPicking() {
-		QueueSettingsManager settings = getParentQueue().getSettingsManager();
-		int mapCount = settings.getMapCount();
-		int poolSize = settings.getMapPool().size();
-		
-		if(mapCount == 0 || poolSize < 2 || (mapCount >= poolSize)) {
-			pickingComplete();
-			return;
-		}
-		
-		new Thread(new Runnable(){
-			public void run(){
-				List<String> mapPool = new ArrayList<>(settings.getMapPool());
-				
-				mapPickController = 
-						new MapPickMenuController(teams[0].getCaptain(), teams[1].getCaptain(), 
-								mapCount, mapPool, settings.getPickStyle());
-				
-				if(!runController(mapPickController)){
-					return;
-				}
-				
-				pickingComplete();
-			}
-		}).start();
-	}
-	
-	private void pickingComplete(){
-		status = GameStatus.PLAYING;
-		teams = pickController.getTeams();
-		
-		createVoiceChannels();
-		postTeamsToPUGChannel();
-	}
-	
-	private void insertPlayersInGame() {
-		for(int i = 0; i < teams.length; i++) {
-			PUGTeam team = teams[i];
-			
-			for(Member player : team.getPlayers()) {
-				Integer pickOrder = team.getPickOrder(player);
-				
-				Database.insertPlayerGame(player.getUser().getIdLong(), timestamp, serverId, pickOrder, i + 1);
-			}
-		}
-	}
-	
-	private void insertCaptains(){
-		long c1 = teams[0].getCaptain().getUser().getIdLong();
-		long c2 = teams[1].getCaptain().getUser().getIdLong();
-		
-		Database.insertPlayerGameCaptain(c1, timestamp, serverId, 1);
-		Database.insertPlayerGameCaptain(c2, timestamp, serverId, 2);
-	}
-	
-	private void postTeamsToPUGChannel(){
-		String output = String.format("**Teams:**%n%s", pickController.getTeamsString());
-		
-		if(mapPickController != null) {
-			String maps = String.join(", ", mapPickController.getPickedMaps());
-			
-			output += String.format("%n%n**Maps:** %s", maps);
-		}
-				
-				
-		TextChannel pugChannel = ServerManager.getServer(serverId).getPugChannel();
-		Message message = Utils.createMessage(String.format("Game '%s' teams picked", getQueueName()),
-											  output, true);
-		
-		for(Member m : players) {
-			if(!isCaptain(m)) {
-				try {
-					m.getUser().openPrivateChannel().complete().sendMessage(message).queue();
-				} catch(Exception ex) {
-					ex.printStackTrace();
-				}
-			}
-		}
-		
-		pugChannel.sendMessage(message).queue();
-	}
-	
-	private void createVoiceChannels() {
-		boolean createChannels = ServerManager.getServer(serverId).getSettingsManager().getCreateTeamVoiceChannels();
-		
-		if(createChannels){
-			Category category = parentQueue.getSettingsManager().getVoiceChannelCategory();
-			
-			teams[0].createVoiceChannel(category);
-			teams[1].createVoiceChannel(category);
-		}
-	}
-	
-	private void deleteVoiceChannels(){
-		teams[0].deleteVoiceChannel();
-		teams[1].deleteVoiceChannel();
-	}
-	
-	protected void finish(){
-		insertCaptains();
-		insertPlayersInGame();
-		insertMaps();
-		
-		status = GameStatus.FINISHED;
-		rpsController = null;
-		pickController = null;
-		mapPickController = null;
-	}
-	
-	protected void cleanup() {
-		cancelMenus();
-		deleteVoiceChannels();
-	}
+        if (players.size() == 2) {
+            teams[0] = new PUGTeam(players.get(0));
+            teams[1] = new PUGTeam(players.get(1));
+            this.players = players;
 
-	/**
-	 * Removes all menus
-	 */
-	private void cancelMenus(){
-		if(pickController != null){
-			pickController.cancel();
-			pickController = null;
-		}
-		
-		if(rpsController != null){
-			rpsController.cancel();
-			rpsController = null;
-		}
-		
-		if(mapPickController != null) {
-			mapPickController.cancel();
-			mapPickController = null;
-		}
-		
-		if(startingOrderConfirmationMenu != null) {
-			startingOrderConfirmationMenu.cancel();
-			startingOrderConfirmationMenu = null;
-		}
-	}
-	
-	/**
-	 * Substitutes one non-captain player for a captain
-	 * 
-	 * @param sub the player replacing a captain
-	 * @param target the captain to be replaced
-	 */
-	public void subCaptain(Member sub, Member target) {
-		if(teams[0].getCaptain() == target){
-			teams[0].setCaptain(sub);
-			teams[0].updateVoiceChannel();
-		}else{
-			teams[1].setCaptain(sub);
-			teams[1].updateVoiceChannel();
-		}
-		
-		if(status == GameStatus.PICKING) {
-			cancelMenus();
-			startRPSGame();
-		}
-	}
-	
-	private void sendGameStartMessages() {
-		Message dm = Utils.createMessage("Game starting",
-				  			String.format("Your game '%s' has begun", getQueueName()), true);
-		TextChannel pugChannel = ServerManager.getServer(serverId).getPugChannel();
-		StringBuilder builder = new StringBuilder();
-		
-		long c1 = teams[0].getCaptain().getUser().getIdLong();
-		long c2 = teams[1].getCaptain().getUser().getIdLong();
-		
-		builder.append(String.format("**Captains: <@%d> & <@%d>**%n", c1, c2));
-		
-		for(Member m : players){
-			if(players.size() > 2 && isCaptain(m)){
-				continue;
-			}
-			
-			try{
-				PrivateChannel pc = m.getUser().openPrivateChannel().complete();
-				
-				pc.sendMessage(dm).queue();
-			}catch(Exception ex){
-				System.out.println("Error sending private message.\n" + ex.getMessage());
-			}
-			
-			
-			
-			builder.append(m.getEffectiveName() + ", ");
-		}
-		
-		builder.delete(builder.length() - 2, builder.length());
-		
-		Message message = Utils.createMessage(String.format("Game '%s' has begun", getQueueName()),
-											  builder.toString(), Color.blue);
-		
-		pugChannel.sendMessage(message).queue();
-	}
-	
-	public boolean isCaptain(Member player){
-		return teams[0].getCaptain() == player || teams[1].getCaptain() == player;
-	}
-	
-	public void repick(){
-		cancelMenus();
-		startConfirmationMenu();
-		status = GameStatus.PICKING;
-	}
-	
-	public PUGTeam getTeam(Member player){
-		if(player == teams[0].getCaptain() || teams[0].getPlayers().contains(player)){
-			return teams[0];
-		}
-		
-		return teams[1];
-	}
-	
-	public void swapPlayers(Member p1, Member p2){
-		PUGTeam p1Team = getTeam(p1);
-		PUGTeam p2Team = getTeam(p2);
-		Integer p1PickOrder = p1Team.getPickOrder(p1);
-		Integer p2PickOrder = p2Team.getPickOrder(p2);
-		
-		p1Team.removePlayer(p1);
-		p1Team.addPlayer(p2, p2PickOrder);
-		p2Team.removePlayer(p2);
-		p2Team.addPlayer(p1, p1PickOrder);
-	}
-	
-	private void insertMaps() {
-		if(mapPickController != null) {
-			for(String map : mapPickController.getPickedMaps()) {
-				Database.insertGameMap(serverId, getParentQueue().getId(), timestamp, map);
-			}
-		}
-	}
-	
-	private boolean runController(IMenuController controller) {
-		IMenuController localController = controller;
-		
-		try {
-			localController.start();
-		} catch(IllegalStateException ex) {
-			TextChannel pugChannel = ServerManager.getServer(serverId).getPugChannel();
-			
-			pugChannel.sendMessage(Utils.createMessage("Error!", ex.getMessage(), false)).queue();;
-		}
-		
-		
-		return !localController.isCancelled();
-	}
+            status = GameStatus.PLAYING;
+            insertCaptains();
+        } else {
+            int minGamesSetting = parentQueue.getSettingsManager().getMinGamesPlayedToCaptain();
+            MatchMaker mm = new MatchMaker(players, serverId, parentQueue.getId(), minGamesSetting);
+            Member[] captains = mm.getRandomizedCaptains();
+            this.players = mm.getOrderedPlayerList();
+
+            teams[0] = new PUGTeam(captains[0]);
+            teams[1] = new PUGTeam(captains[1]);
+
+            startRPSGame();
+        }
+
+        sendGameStartMessages();
+    }
+
+    public enum GameStatus {
+        PICKING,
+        PLAYING,
+        FINISHED
+    }
+
+    /**
+     * @return the list of players in this game
+     */
+    public List<Member> getPlayers() {
+        return players;
+    }
+
+    /**
+     * @return the start time of this game in milliseconds
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Substitutes one player in game with one out of game
+     *
+     * @param target     the player to replace
+     * @param substitute the player that will replace the target
+     */
+    public void sub(Member target, Member substitute) {
+        players.remove(target);
+        players.add(substitute);
+
+        if (target == teams[0].getCaptain() || target == teams[1].getCaptain()) {
+            subCaptain(substitute, target);
+        } else {
+            if (status == GameStatus.PLAYING) {
+                if (teams[0].getPlayers().contains(target)) {
+                    teams[0].removePlayer(target);
+                    teams[0].addPlayer(substitute, null);
+                } else {
+                    teams[1].removePlayer(target);
+                    teams[1].addPlayer(substitute, null);
+                }
+            }
+
+            if (status == GameStatus.PICKING && pickController != null) {
+                cancelMenus();
+                startPUGPicking();
+            }
+        }
+    }
+
+    public boolean containsPlayer(Member player) {
+        return players.contains(player);
+    }
+
+    public PUGTeam[] getPUGTeams() {
+        return teams;
+    }
+
+    /**
+     * @return the name of the queue that this game is from
+     */
+    public String getQueueName() {
+        return parentQueue.getName();
+    }
+
+    public Queue getParentQueue() {
+        return parentQueue;
+    }
+
+    /**
+     * @return the current status of this game
+     */
+    public GameStatus getStatus() {
+        return status;
+    }
+
+    private void startRPSGame() {
+        new Thread(new Runnable() {
+            public void run() {
+                rpsController = new RPSMenuController(teams[0].getCaptain(), teams[1].getCaptain());
+
+                if (!runController(rpsController)) {
+                    return;
+                }
+
+                Member winner = rpsController.getWinner();
+
+                if (teams[1].getCaptain() == winner) {
+                    teams[1].setCaptain(teams[0].getCaptain());
+                    teams[0].setCaptain(winner);
+                }
+
+                startConfirmationMenu();
+            }
+        }).start();
+    }
+
+    private void startConfirmationMenu() {
+        new Thread(new Runnable() {
+            public void run() {
+                startingOrderConfirmationMenu = new ConfirmationMenu(teams[0].getCaptain(), "Take first pick?");
+
+                if (!runController(startingOrderConfirmationMenu)) {
+                    return;
+                }
+
+                if (!startingOrderConfirmationMenu.getResult()) {
+                    Member tmp = teams[0].getCaptain();
+
+                    teams[0].setCaptain(teams[1].getCaptain());
+                    teams[1].setCaptain(tmp);
+                }
+
+                startPUGPicking();
+            }
+        }).start();
+    }
+
+    private void startPUGPicking() {
+        new Thread(new Runnable() {
+            public void run() {
+                List<Member> playerPool = new ArrayList<Member>(players);
+                String pickingPattern = parentQueue.getSettingsManager().getPickPattern();
+
+                playerPool.remove(teams[0].getCaptain());
+                playerPool.remove(teams[1].getCaptain());
+
+                pickController =
+                        new PUGPickMenuController(teams[0].getCaptain(), teams[1].getCaptain(), playerPool, pickingPattern);
+
+                if (!runController(pickController)) {
+                    return;
+                }
+
+                startMapPicking();
+            }
+        }).start();
+    }
+
+    private void startMapPicking() {
+        QueueSettingsManager settings = getParentQueue().getSettingsManager();
+        int mapCount = settings.getMapCount();
+        int poolSize = settings.getMapPool().size();
+
+        if (mapCount == 0 || poolSize < 2 || (mapCount >= poolSize)) {
+            pickingComplete();
+            return;
+        }
+
+        new Thread(new Runnable() {
+            public void run() {
+                List<String> mapPool = new ArrayList<>(settings.getMapPool());
+
+                mapPickController =
+                        new MapPickMenuController(teams[0].getCaptain(), teams[1].getCaptain(),
+                                mapCount, mapPool, settings.getPickStyle());
+
+                if (!runController(mapPickController)) {
+                    return;
+                }
+
+                pickingComplete();
+            }
+        }).start();
+    }
+
+    private void pickingComplete() {
+        status = GameStatus.PLAYING;
+        teams = pickController.getTeams();
+
+        createVoiceChannels();
+        postTeamsToPUGChannel();
+    }
+
+    /**
+     * Teams were set manually
+     */
+    public void setTeamsComplete() {
+        status = GameStatus.PLAYING;
+
+        createVoiceChannels();
+        postTeamsToPUGChannel();
+    }
+
+    private void insertPlayersInGame() {
+        for (int i = 0; i < teams.length; i++) {
+            PUGTeam team = teams[i];
+
+            for (Member player : team.getPlayers()) {
+                Integer pickOrder = team.getPickOrder(player);
+
+                Database.insertPlayerGame(player.getUser().getIdLong(), timestamp, serverId, pickOrder, i + 1);
+            }
+        }
+    }
+
+    private void insertCaptains() {
+        long c1 = teams[0].getCaptain().getUser().getIdLong();
+        long c2 = teams[1].getCaptain().getUser().getIdLong();
+
+        Database.insertPlayerGameCaptain(c1, timestamp, serverId, 1);
+        Database.insertPlayerGameCaptain(c2, timestamp, serverId, 2);
+    }
+
+    private void postTeamsToPUGChannel() {
+        String output = "";
+        if (pickController != null) {
+            output += String.format("**Teams:**%n%s", pickController.getTeamsString());
+        }
+
+        if (mapPickController != null) {
+            String maps = String.join(", ", mapPickController.getPickedMaps());
+
+            output += String.format("%n%n**Maps:** %s", maps);
+        }
+
+
+        TextChannel pugChannel = ServerManager.getServer(serverId).getPugChannel();
+        Message message = Utils.createMessage(String.format("Game '%s' teams picked", getQueueName()),
+                output, true);
+
+        for (Member m : players) {
+            if (!isCaptain(m)) {
+                try {
+                    m.getUser().openPrivateChannel().complete().sendMessage(message).queue();
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                }
+            }
+        }
+
+        pugChannel.sendMessage(message).queue();
+    }
+
+    private void createVoiceChannels() {
+        boolean createChannels = ServerManager.getServer(serverId).getSettingsManager().getCreateTeamVoiceChannels();
+
+        if (createChannels) {
+            Category category = parentQueue.getSettingsManager().getVoiceChannelCategory();
+
+            teams[0].createVoiceChannel(category);
+            teams[1].createVoiceChannel(category);
+        }
+    }
+
+    private void deleteVoiceChannels() {
+        teams[0].deleteVoiceChannel();
+        teams[1].deleteVoiceChannel();
+    }
+
+    protected void finish() {
+        insertCaptains();
+        insertPlayersInGame();
+        insertMaps();
+
+        status = GameStatus.FINISHED;
+        rpsController = null;
+        pickController = null;
+        mapPickController = null;
+    }
+
+    protected void cleanup() {
+        cancelMenus();
+        deleteVoiceChannels();
+    }
+
+    /**
+     * Removes all menus
+     */
+    private void cancelMenus() {
+        if (pickController != null) {
+            pickController.cancel();
+            pickController = null;
+        }
+
+        if (rpsController != null) {
+            rpsController.cancel();
+            rpsController = null;
+        }
+
+        if (mapPickController != null) {
+            mapPickController.cancel();
+            mapPickController = null;
+        }
+
+        if (startingOrderConfirmationMenu != null) {
+            startingOrderConfirmationMenu.cancel();
+            startingOrderConfirmationMenu = null;
+        }
+    }
+
+    /**
+     * Substitutes one non-captain player for a captain
+     *
+     * @param sub    the player replacing a captain
+     * @param target the captain to be replaced
+     */
+    public void subCaptain(Member sub, Member target) {
+        if (teams[0].getCaptain() == target) {
+            teams[0].setCaptain(sub);
+            teams[0].updateVoiceChannel();
+        } else {
+            teams[1].setCaptain(sub);
+            teams[1].updateVoiceChannel();
+        }
+
+        if (status == GameStatus.PICKING) {
+            cancelMenus();
+            startRPSGame();
+        }
+    }
+
+    private void sendGameStartMessages() {
+        Message dm = Utils.createMessage("Game starting",
+                String.format("Your game '%s' has begun", getQueueName()), true);
+        TextChannel pugChannel = ServerManager.getServer(serverId).getPugChannel();
+        StringBuilder builder = new StringBuilder();
+
+        long c1 = teams[0].getCaptain().getUser().getIdLong();
+        long c2 = teams[1].getCaptain().getUser().getIdLong();
+
+        builder.append(String.format("**Captains: <@%d> & <@%d>**%n", c1, c2));
+
+        for (Member m : players) {
+            if (players.size() > 2 && isCaptain(m)) {
+                continue;
+            }
+
+            try {
+                PrivateChannel pc = m.getUser().openPrivateChannel().complete();
+
+                pc.sendMessage(dm).queue();
+            } catch (Exception ex) {
+                System.out.println("Error sending private message.\n" + ex.getMessage());
+            }
+
+
+            builder.append(m.getEffectiveName() + ", ");
+        }
+
+        builder.delete(builder.length() - 2, builder.length());
+
+        Message message = Utils.createMessage(String.format("Game '%s' has begun", getQueueName()),
+                builder.toString(), Color.blue);
+
+        pugChannel.sendMessage(message).queue();
+    }
+
+    public boolean isCaptain(Member player) {
+        return teams[0].getCaptain() == player || teams[1].getCaptain() == player;
+    }
+
+    public void repick() {
+        cancelMenus();
+        startConfirmationMenu();
+        status = GameStatus.PICKING;
+    }
+
+    public PUGTeam getTeam(Member player) {
+        if (player == teams[0].getCaptain() || teams[0].getPlayers().contains(player)) {
+            return teams[0];
+        }
+
+        return teams[1];
+    }
+
+    public void swapPlayers(Member p1, Member p2) {
+        PUGTeam p1Team = getTeam(p1);
+        PUGTeam p2Team = getTeam(p2);
+        Integer p1PickOrder = p1Team.getPickOrder(p1);
+        Integer p2PickOrder = p2Team.getPickOrder(p2);
+
+        p1Team.removePlayer(p1);
+        p1Team.addPlayer(p2, p2PickOrder);
+        p2Team.removePlayer(p2);
+        p2Team.addPlayer(p1, p1PickOrder);
+    }
+
+    private void insertMaps() {
+        if (mapPickController != null) {
+            for (String map : mapPickController.getPickedMaps()) {
+                Database.insertGameMap(serverId, getParentQueue().getId(), timestamp, map);
+            }
+        }
+    }
+
+    private boolean runController(IMenuController controller) {
+        IMenuController localController = controller;
+
+        try {
+            localController.start();
+        } catch (IllegalStateException ex) {
+            TextChannel pugChannel = ServerManager.getServer(serverId).getPugChannel();
+
+            pugChannel.sendMessage(Utils.createMessage("Error!", ex.getMessage(), false)).queue();
+            ;
+        }
+
+
+        return !localController.isCancelled();
+    }
 }

--- a/src/main/java/pugbot/core/entities/PUGTeam.java
+++ b/src/main/java/pugbot/core/entities/PUGTeam.java
@@ -47,7 +47,11 @@ public class PUGTeam {
 	public void removePlayer(Member player) {
 		playerMap.remove(player);
 	}
-	
+
+	public void clearPlayers() {
+		playerMap.clear();
+	}
+
 	@Override
 	public String toString(){
 		StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
This adds a new command called `!setteams` where players can set the teams manually. Example invocation:

```
!setteams @opsayo @adroit @lordkermit @lyon @raven vs @implosions @fyr @stork @clown @jester
```

This is motivated by the t1 community creating teams using trueskill, so we can copy paste a command to automatically create the teams without going through the picking process.